### PR TITLE
Add snapshot URL support

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -5,4 +5,5 @@ type DAO @entity(immutable: false) {
   name: String
   hierarchy: [DAO!]!
   proposalTemplatesHash: String # IPFS Hash
+  snapshotURL: String
 }

--- a/src/key-value-pairs.ts
+++ b/src/key-value-pairs.ts
@@ -13,6 +13,16 @@ export function handleValueUpdated(event: ValueUpdatedEvent): void {
       dao.proposalTemplatesHash = event.params.value;
       dao.save();
     }
+  } else if (event.params.key == 'snapshotURL') {
+    let dao = DAO.load(event.params.theAddress);
+    if (dao) {
+      log.info('Processing Snapshot URL for DAO: {}, the URL is: {}', [
+        event.params.theAddress.toHexString(),
+        event.params.value,
+      ]);
+      dao.snapshotURL = event.params.value;
+      dao.save();
+    }
   } else {
     log.warning('Unkown key: {}', [event.params.key]);
   }


### PR DESCRIPTION
This PR adds support for the Subgraph to index snapshotURLs that are emitted by events on the `KeyValuePairs` contract by DAOs.